### PR TITLE
Ob 358 display initial date

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,10 +20,13 @@
   "dependencies": {
     "ll-date-picker": "LeisureLinkElements/ll-date-picker",
     "polymer": "Polymer/polymer#^1.0.0",
-    "moment": "~2.8.3"
+    "moment": "^2.10.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "web-component-tester": "*"
+  },
+  "resolutions": {
+    "moment": "^2.10.0"
   }
 }

--- a/ll-date-input.html
+++ b/ll-date-input.html
@@ -109,6 +109,7 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
 
     _initDisplay: function() {
       this.value = this._formatDate(this.dataData, 'display');
+      this.style.cursor = 'pointer';
     }
 
   });

--- a/ll-date-input.html
+++ b/ll-date-input.html
@@ -39,7 +39,7 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
 
       formats: {
         type: Object,
-        value: function(){
+        value: function () {
           return {};
         }
       }
@@ -50,10 +50,10 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
       this.readOnly = true;
     },
 
-    ready: function() {
+    ready: function () {
       this.formats.data = this.dataset.dataFormat || 'YYYY-MM-DDTHH:mm:ss[Z]';
       this.formats.display = this.dataset.displayFormat || 'M/D/YY';
-      this._initDisplay();
+      this._format();
     },
 
     /**
@@ -78,27 +78,27 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
      * @param data {object} Contains display and data strings. display string not used currently.
      */
     datePicked: function (data) {
-      this.dataData = this._formatDate(data.data, 'data');
+      this.dataData = this._getFormattedDate(data.data, 'data');
     },
 
     _tap: function () {
       this._datePicker.open(this, this.dataData, this.formats.display, this.formats.data);
     },
 
-    _dataChanged: function (newVal) {
-      this.value = this._formatDate(newVal, 'display');
-      this.fire('ll-date-input-change', newVal);
+    _dataChanged: function () {
+      this._format();
+      this.fire('ll-date-input-change', this.dataData);
     },
 
     /**
-     * Converts data date string like '18:30:22' and converts to '6:30 PM'
+     * Convert a date string to either the data or display format.
      *
      * @param dataStr {string}
      * @param formatType {string} Either "data" or "display"
      * @returns {string}
      * @private
      */
-    _formatDate: function (dataStr, formatType) {
+    _getFormattedDate: function (dataStr, formatType) {
       var m = moment(dataStr, this.formats['data']);
       if (m.isValid()) {
         return m.format(this.formats[formatType]);
@@ -107,9 +107,13 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
       }
     },
 
-    _initDisplay: function() {
-      this.value = this._formatDate(this.dataData, 'display');
-      this.style.cursor = 'pointer';
+    /**
+     * Format both data and display values.
+     * @private
+     */
+    _format: function () {
+      this.dataData = this._getFormattedDate(this.dataData, 'data');
+      this.value = this._getFormattedDate(this.dataData, 'display');
     }
 
   });

--- a/ll-date-input.html
+++ b/ll-date-input.html
@@ -53,6 +53,7 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
     ready: function() {
       this.formats.data = this.dataset.dataFormat || 'YYYY-MM-DDTHH:mm:ss[Z]';
       this.formats.display = this.dataset.displayFormat || 'M/D/YY';
+      this._initDisplay();
     },
 
     /**
@@ -102,6 +103,10 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
       if (m.isValid()) {
         return m.format(this.formats[formatType]);
       }
+    },
+
+    _initDisplay: function() {
+      this.value = this._formatDate(this.dataData, 'display');
     }
 
   });

--- a/ll-date-input.html
+++ b/ll-date-input.html
@@ -102,6 +102,8 @@ A clickable, read-only text input that launches ll-date-picker to set its displa
       var m = moment(dataStr, this.formats['data']);
       if (m.isValid()) {
         return m.format(this.formats[formatType]);
+      } else {
+        return '';
       }
     },
 

--- a/test/tests.html
+++ b/test/tests.html
@@ -31,11 +31,11 @@
     describe('date formatting', function () {
 
       it('should convert valid DATA date strings to "M/D/YY" format', function () {
-        expect(myEl._formatDate('2016-08-20', 'display')).to.eql('8/20/16');
+        expect(myEl._getFormattedDate('2016-08-20', 'display')).to.eql('8/20/16');
       });
 
       it('should convert invalid DATA date string to empty string', function () {
-        expect(myEl._formatDate('2016-13-20')).to.eql('');
+        expect(myEl._getFormattedDate('2016-13-20')).to.eql('');
       });
 
       it('should display date correctly when the DATA value is set programatically', function () {

--- a/test/tests.html
+++ b/test/tests.html
@@ -34,8 +34,13 @@
         expect(myEl._formatDate('2016-08-20', 'display')).to.eql('8/20/16');
       });
 
-      it('should convert invalid DATA date string to undefined', function () {
-        expect(myEl._formatDate('2016-13-20')).to.eql(undefined);
+      it('should convert invalid DATA date string to empty string', function () {
+        expect(myEl._formatDate('2016-13-20')).to.eql('');
+      });
+
+      it('should display date correctly when the DATA value is set programatically', function () {
+        myEl.dataData = '2017-03-20T00:00:00Z';
+        expect(myEl.value).to.eql('3/20/17');
       });
 
     });


### PR DESCRIPTION
This corrects the initial display of the date within the input when its data-bound value is already set when the input is ready. To elaborate, this element has two values: The "value" which is the native input's value displayed inside the input, and the "data" value which is stored in the "dataData" property and reflected to the "data-data" attribute. You can bind the "data-data" attribute using markup, either 1-way or 2-way.

This change makes sure that when the input is initially displayed, and has a value for the "data-data" attribute, it sets its native "value" to the correctly-formatted date based on the value of formats.data.
